### PR TITLE
セミナー情報の更新、 Speakers に漏れがあったため微調整を実施

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -166,6 +166,13 @@
 
             <span class="w-45 w-15-l center inline-flex flex-column items-center pa2 mv1 v-mid h-100">
               <a href="#" class="top-speakers-link">
+                <img class="w-100 mb2" src="https://serverlessmeetup.s3.ap-northeast-1.amazonaws.com/kaysawada-headshot.jpg" alt="澤田径">
+                <p class="ma0 f8 w-100 primaryTokyoColor lh-copy tc"><span class="b f7">澤田径</span><br>TBA</p>
+              </a>
+            </span>
+
+            <span class="w-45 w-15-l center inline-flex flex-column items-center pa2 mv1 v-mid h-100">
+              <a href="#" class="top-speakers-link">
                 <img class="w-100 mb2" src="https://serverlessmeetup.s3.ap-northeast-1.amazonaws.com/shimizu_yusuke.jpeg" alt="志水友輔">
                 <p class="ma0 f8 w-100 primaryTokyoColor lh-copy tc"><span class="b f7">志水友輔</span><br>「完璧を目指さない」サーバーレス進化論　〜CDKで育てる変化に強いアーキテクチャ〜</p>
               </a>
@@ -223,7 +230,7 @@
             <span class="w-45 w-15-l center inline-flex flex-column items-center pa2 mv1 v-mid h-100">
               <a href="#" class="top-speakers-link">
                 <img class="w-100 mb2" src="https://aoai-devday.com/images/2025/members/miyake.jpg" alt="三宅和之">
-                <p class="ma0 f8 w-100 primaryTokyoColor lh-copy tc"><span class="b f7">三宅和之</span><br>TBA</p>
+                <p class="ma0 f8 w-100 primaryTokyoColor lh-copy tc"><span class="b f7">三宅和之</span><br>Azure Serverless × AI Agent × MCP アーキテクチャ最前線</p>
               </a>
             </span>
 
@@ -597,11 +604,11 @@
                 </div>
                 <div class="pv3 pl2 pr3 v-mid">
                   <div class="f5 i">
-                    TBA
+                    Azure Serverless × AI Agent × MCP アーキテクチャ最前線
                   </div>
                   <div class="f5 b">
                     <div>
-                      TBA (ZEN Architects)
+                      三宅和之 (ZEN Architects)
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
ゼンアーキテクツさまから情報がきたため、追加。

外部の Speakers に漏れがあったため、適当な場所に追加し、差分をなくしました。